### PR TITLE
[Issue #8] Çoklu satır temizlemede skor hesaplama hatası düzeltmesi

### DIFF
--- a/game.js
+++ b/game.js
@@ -238,7 +238,7 @@ function clearLines() {
         }
     }
     if (cleared > 0) {
-        const points = 100 * level;
+        const points = (SCORE_TABLE[cleared] || cleared * 100) * level;
         score += points;
         lines += cleared;
         const newLevel = Math.floor(lines / LINES_PER_LEVEL) + 1;


### PR DESCRIPTION
## Bug Düzeltmesi
2+ satır aynı anda temizlendiğinde skor sadece 100×seviye olarak hesaplanıyordu.

## Değişiklikler
- `SCORE_TABLE` lookup geri eklendi: 1=100, 2=300, 3=500, 4=800
- Skor hesaplaması temizlenen satır sayısına göre doğru çarpan kullanıyor

## Test
- 1 satır = 100 × seviye
- 2 satır = 300 × seviye  
- 3 satır = 500 × seviye
- 4 satır (Tetris) = 800 × seviye

Closes #8