### PR TITLE
[Issue #23] GitHub Pages: her merge sonrasi otomatik deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Degisiklikler
- `.github/workflows/deploy.yml` eklendi
- main branch her push'ta GitHub Pages'e deploy
- Static dosyalar (HTML/CSS/JS) dogrudan serve ediliyor
- Manual workflow_dispatch ile yeniden deploy secenegi
- Concurrency kontrolu ile paralel deploy onleme

**Not:** Merge sonrasi repoda Settings > Pages kisminda "GitHub Actions" source secilmeli.

Closes #23